### PR TITLE
Fix 404 on dev server by using relative paths in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/mytask/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MyTask — Pomodoro Timer</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Absolute paths (/src/main.tsx, /mytask/favicon.svg) were bypassing Vite's base rewriting when base: '/mytask/' is set in vite.config.ts. Switching to relative paths (./src/main.tsx, ./favicon.svg) lets Vite resolve them correctly in both dev and production builds.