### PR TITLE
[bug] Fix timer keeps running after active task is completed

### DIFF
--- a/src/context/TimerContext.tsx
+++ b/src/context/TimerContext.tsx
@@ -98,7 +98,8 @@ export function TimerProvider({ children }: { children: React.ReactNode }) {
     const newCount = mode === 'focus' ? sessionCount + 1 : sessionCount;
     if (mode === 'focus') {
       setSessionCount(newCount);
-      if (activeTaskId) incrementTaskPomodoro(activeTaskId);
+      const activeTask = state.tasks.find(t => t.id === activeTaskId);
+      if (activeTaskId && !activeTask?.completed) incrementTaskPomodoro(activeTaskId);
 
       addSession({
         id: randomId(),
@@ -182,7 +183,8 @@ export function TimerProvider({ children }: { children: React.ReactNode }) {
     if (mode === 'focus') {
       const newCount = sessionCount + 1;
       setSessionCount(newCount);
-      if (activeTaskId) incrementTaskPomodoro(activeTaskId);
+      const activeTask = state.tasks.find(t => t.id === activeTaskId);
+      if (activeTaskId && !activeTask?.completed) incrementTaskPomodoro(activeTaskId);
 
       addSession({
         id: randomId(),

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTimer } from '../hooks/useTimer';
 import { useApp } from '../hooks/useApp';
 import { useLang } from '../hooks/useLang';
@@ -27,6 +27,16 @@ export function TimerPage() {
   const { state, clearCompletedTasks } = useApp();
   const { t } = useLang();
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null);
+
+  // Pause and deselect if the active task is marked complete while timer is running
+  useEffect(() => {
+    if (!timer.activeTaskId || !timer.running) return;
+    const activeTask = state.tasks.find(t => t.id === timer.activeTaskId);
+    if (activeTask?.completed) {
+      timer.pause();
+      timer.switchTask(null);
+    }
+  }, [state.tasks, timer.activeTaskId, timer.running]);
 
   const today = todayStr();
   const todayTasks = state.tasks


### PR DESCRIPTION
## Summary
- When the active task is marked complete mid-session, the timer now **pauses immediately** and the task is deselected — no more phantom pomodoros
- Added a data-integrity guard in `TimerContext` so `incrementTaskPomodoro` is never called on a completed task, protecting against auto-start race conditions too

## Test plan
- [ ] Start timer on a task → check off the task → timer pauses, task deselects
- [ ] Uncheck the task → select it again → timer resumes normally
- [ ] Enable auto-start breaks → complete task mid-session → timer stops (does not auto-advance into break while task is completed)
- [ ] Complete a *different* (non-active) task while timer is running → timer is unaffected

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)