### PR TITLE
[feature] ユーザが主導的にSyncできるようにしたい

### DIFF
--- a/src/components/shared/PullToRefresh.tsx
+++ b/src/components/shared/PullToRefresh.tsx
@@ -1,0 +1,81 @@
+import React, { useRef, useState } from 'react';
+import { useLang } from '../../hooks/useLang';
+
+const PULL_THRESHOLD = 80;
+
+interface Props {
+  onRefresh: () => Promise<void>;
+  children: React.ReactNode;
+}
+
+export function PullToRefresh({ onRefresh, children }: Props) {
+  const { t } = useLang();
+  const startYRef = useRef<number | null>(null);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  function handleTouchStart(e: React.TouchEvent) {
+    // Only track pull-to-refresh when scrolled to top
+    if (window.scrollY > 0) return;
+    startYRef.current = e.touches[0].clientY;
+  }
+
+  function handleTouchMove(e: React.TouchEvent) {
+    if (startYRef.current === null || refreshing) return;
+    const delta = e.touches[0].clientY - startYRef.current;
+    if (delta > 0) {
+      setPullDistance(Math.min(delta, PULL_THRESHOLD * 1.5));
+    }
+  }
+
+  async function handleTouchEnd() {
+    if (pullDistance >= PULL_THRESHOLD && !refreshing) {
+      setRefreshing(true);
+      setPullDistance(0);
+      startYRef.current = null;
+      await onRefresh();
+      setRefreshing(false);
+    } else {
+      setPullDistance(0);
+      startYRef.current = null;
+    }
+  }
+
+  const progress = Math.min(pullDistance / PULL_THRESHOLD, 1);
+  const showIndicator = pullDistance > 8 || refreshing;
+  const released = pullDistance >= PULL_THRESHOLD;
+
+  return (
+    <div
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      {showIndicator && (
+        <div
+          className="flex items-center justify-center gap-2 text-white/70 text-xs overflow-hidden transition-all duration-200"
+          style={{ height: refreshing ? 40 : pullDistance * 0.5 }}
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={`w-4 h-4 transition-transform duration-200 ${refreshing ? 'animate-spin' : ''}`}
+            style={{ transform: refreshing ? undefined : `rotate(${progress * 180}deg)` }}
+          >
+            <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+            <path d="M21 3v5h-5" />
+            <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+            <path d="M8 16H3v5" />
+          </svg>
+          <span>{refreshing ? t.auth.syncing : released ? t.auth.releaseToRefresh : t.auth.pullToRefresh}</span>
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/src/components/shared/SyncButton.tsx
+++ b/src/components/shared/SyncButton.tsx
@@ -1,0 +1,32 @@
+import { useApp } from '../../hooks/useApp';
+import { useLang } from '../../hooks/useLang';
+
+export function SyncButton() {
+  const { syncing, manualSync } = useApp();
+  const { t } = useLang();
+
+  return (
+    <button
+      onClick={manualSync}
+      disabled={syncing}
+      aria-label={t.auth.syncNow}
+      className="p-2 rounded-full text-white/60 hover:text-white/90 active:text-white transition-colors disabled:opacity-40"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={`w-5 h-5 ${syncing ? 'animate-spin' : ''}`}
+      >
+        <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+        <path d="M21 3v5h-5" />
+        <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+        <path d="M8 16H3v5" />
+      </svg>
+    </button>
+  );
+}

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -7,6 +7,7 @@ import { loadFromDynamo, saveToDynamo } from '../utils/dynamoSync';
 interface AppContextValue {
   state: AppState;
   syncing: boolean;
+  manualSync: () => Promise<void>;
   addTask: (t: Task) => void;
   updateTask: (t: Task) => void;
   deleteTask: (id: string) => void;
@@ -60,9 +61,21 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     return () => { if (saveTimer.current) clearTimeout(saveTimer.current); };
   }, [state]);
 
+  async function manualSync() {
+    setSyncing(true);
+    const { state: remote, identityId } = await loadFromDynamo();
+    if (remote) {
+      dispatch({ type: 'LOAD_STATE', payload: remote });
+      saveState(remote);
+      if (identityId) saveIdentity(identityId);
+    }
+    setSyncing(false);
+  }
+
   const ctx: AppContextValue = {
     state,
     syncing,
+    manualSync,
     addTask: (t) => dispatch({ type: 'ADD_TASK', payload: t }),
     updateTask: (t) => dispatch({ type: 'UPDATE_TASK', payload: t }),
     deleteTask: (id) => dispatch({ type: 'DELETE_TASK', payload: id }),

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -90,6 +90,9 @@ const en = {
   auth: {
     signOut: 'Sign out',
     syncing: 'Syncing…',
+    syncNow: 'Sync',
+    pullToRefresh: 'Pull to refresh',
+    releaseToRefresh: 'Release to refresh',
     signInHeader: 'Sign in to MyTask',
     signUpHeader: 'Create your account',
     loggedInAs: 'Logged in as',
@@ -186,6 +189,9 @@ const ja: typeof en = {
   auth: {
     signOut: 'サインアウト',
     syncing: '同期中…',
+    syncNow: '同期',
+    pullToRefresh: '引っ張って更新',
+    releaseToRefresh: '離して更新',
     signInHeader: 'MyTask にサインイン',
     signUpHeader: 'アカウントを作成',
     loggedInAs: 'ログイン中',

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -8,6 +8,8 @@ import { TimerControls } from '../components/timer/TimerControls';
 import { AddTaskForm } from '../components/tasks/AddTaskForm';
 import { TaskItem } from '../components/tasks/TaskItem';
 import { ConfirmModal } from '../components/shared/ConfirmModal';
+import { SyncButton } from '../components/shared/SyncButton';
+import { PullToRefresh } from '../components/shared/PullToRefresh';
 import { todayStr } from '../utils/formatters';
 import type { TimerMode } from '../hooks/useTimer';
 
@@ -24,7 +26,7 @@ interface PendingConfirm {
 
 export function TimerPage() {
   const timer = useTimer();
-  const { state, clearCompletedTasks } = useApp();
+  const { state, clearCompletedTasks, manualSync } = useApp();
   const { t } = useLang();
   const [pendingConfirm, setPendingConfirm] = useState<PendingConfirm | null>(null);
 
@@ -78,10 +80,17 @@ export function TimerPage() {
   }
 
   return (
+    <PullToRefresh onRefresh={manualSync}>
     <div className={`min-h-screen bg-gradient-to-br ${bgGradient} transition-all duration-700`}>
       <div className="max-w-xl mx-auto px-4 py-8 flex flex-col items-center gap-6">
 
-        <TimerModeSelector mode={timer.mode} onSwitch={handleSwitchMode} />
+        <div className="w-full flex items-center justify-between">
+          <div className="flex-1" />
+          <TimerModeSelector mode={timer.mode} onSwitch={handleSwitchMode} />
+          <div className="flex-1 flex justify-end">
+            <SyncButton />
+          </div>
+        </div>
 
         <div className="flex flex-col items-center gap-4">
           <TimerDisplay display={timer.display} progress={timer.progress} mode={timer.mode} />
@@ -154,5 +163,6 @@ export function TimerPage() {
         />
       )}
     </div>
+    </PullToRefresh>
   );
 }


### PR DESCRIPTION
## Summary

- Added a **sync button** (always visible) in the top-right of the Timer page that triggers a pull from DynamoDB followed by a local state update
- Added **pull-to-refresh** on mobile: pulling down from the top of the screen shows a visual indicator (arrow + label), and releasing at threshold triggers the same sync
- Syncing state disables the button and shows a spinner; pull-to-refresh shows "Syncing…" during the operation
- Translations added for both `en` and `ja` (`syncNow`, `pullToRefresh`, `releaseToRefresh`)

## Changes

- `src/context/AppContext.tsx` — exposed `manualSync()` on context
- `src/i18n/translations.ts` — added sync UI strings
- `src/components/shared/SyncButton.tsx` — new sync icon button component
- `src/components/shared/PullToRefresh.tsx` — new pull-to-refresh wrapper component
- `src/pages/TimerPage.tsx` — integrated both components

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)