### PR TITLE
[bug] Fix tasks disappearing due to destructive sync

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useReducer, useEffect, useRef, useState } from 'react';
 import type { AppState, Task, Session, Settings } from '../types';
 import { appReducer } from './reducer';
-import { loadState, saveState, loadStoredIdentity, saveIdentity, defaultAppState } from '../utils/storage';
+import { loadState, saveState, loadStoredIdentity, saveIdentity, defaultAppState, mergeStates } from '../utils/storage';
 import { loadFromDynamo, saveToDynamo } from '../utils/dynamoSync';
 
 interface AppContextValue {
@@ -39,8 +39,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         saveState(fresh);
         saveIdentity(identityId);
       } else if (remote) {
-        dispatch({ type: 'LOAD_STATE', payload: remote });
-        saveState(remote);
+        const local = loadState();
+        const merged = mergeStates(local, remote);
+        dispatch({ type: 'LOAD_STATE', payload: merged });
+        saveState(merged);
         if (identityId) saveIdentity(identityId);
       } else if (identityId) {
         saveIdentity(identityId);
@@ -52,8 +54,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
-    if (loadingFromRemote.current) return;
-    saveState(state);
+    saveState(state);                        // always keep localStorage current
+    if (loadingFromRemote.current) return;   // guard only the DynamoDB write
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(() => {
       saveToDynamo(state);
@@ -63,11 +65,15 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   async function manualSync() {
     setSyncing(true);
+    if (saveTimer.current) clearTimeout(saveTimer.current); // cancel any pending stale write
     const { state: remote, identityId } = await loadFromDynamo();
     if (remote) {
-      dispatch({ type: 'LOAD_STATE', payload: remote });
-      saveState(remote);
+      const local = loadState();
+      const merged = mergeStates(local, remote);
+      dispatch({ type: 'LOAD_STATE', payload: merged });
+      saveState(merged);
       if (identityId) saveIdentity(identityId);
+      await saveToDynamo(merged); // push merged state immediately
     }
     setSyncing(false);
   }

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -17,16 +17,17 @@ export function appReducer(state: AppState, action: Action): AppState {
       return action.payload;
 
     case 'ADD_TASK':
-      return { ...state, tasks: [...state.tasks, action.payload] };
+      return { ...state, tasks: [...state.tasks, action.payload], updatedAt: new Date().toISOString() };
 
     case 'UPDATE_TASK':
       return {
         ...state,
         tasks: state.tasks.map(t => t.id === action.payload.id ? action.payload : t),
+        updatedAt: new Date().toISOString(),
       };
 
     case 'DELETE_TASK':
-      return { ...state, tasks: state.tasks.filter(t => t.id !== action.payload) };
+      return { ...state, tasks: state.tasks.filter(t => t.id !== action.payload), updatedAt: new Date().toISOString() };
 
     case 'CLEAR_COMPLETED_TASKS':
       return {
@@ -36,10 +37,11 @@ export function appReducer(state: AppState, action: Action): AppState {
             ? { ...t, archivedAt: new Date().toISOString() }
             : t
         ),
+        updatedAt: new Date().toISOString(),
       };
 
     case 'ADD_SESSION':
-      return { ...state, sessions: [...state.sessions, action.payload] };
+      return { ...state, sessions: [...state.sessions, action.payload], updatedAt: new Date().toISOString() };
 
     case 'INCREMENT_TASK_POMODORO':
       return {
@@ -49,10 +51,11 @@ export function appReducer(state: AppState, action: Action): AppState {
             ? { ...t, completedPomodoros: t.completedPomodoros + 1 }
             : t
         ),
+        updatedAt: new Date().toISOString(),
       };
 
     case 'UPDATE_SETTINGS':
-      return { ...state, settings: action.payload };
+      return { ...state, settings: action.payload, updatedAt: new Date().toISOString() };
 
     case 'SET_DATE':
       return { ...state, selectedDate: action.payload };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,4 +36,5 @@ export interface AppState {
   sessions: Session[];
   settings: Settings;
   selectedDate: string; // YYYY-MM-DD
+  updatedAt?: string;   // ISO timestamp — set on every local mutation; used for merge conflict resolution
 }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -14,6 +14,26 @@ export function defaultAppState(): AppState {
     sessions: [],
     settings: { ...DEFAULT_SETTINGS },
     selectedDate: todayStr(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export function mergeStates(local: AppState, remote: AppState): AppState {
+  // The newer source (by updatedAt) is primary for settings and task state.
+  // Tasks and sessions from the older source that don't exist in the primary are always added,
+  // so tasks are never silently dropped across devices.
+  const remoteNewer = (remote.updatedAt ?? '') > (local.updatedAt ?? '');
+  const primary = remoteNewer ? remote : local;
+  const secondary = remoteNewer ? local : remote;
+
+  const taskIds = new Set(primary.tasks.map(t => t.id));
+  const sessionIds = new Set(primary.sessions.map(s => s.id));
+
+  return {
+    ...primary,
+    tasks: [...primary.tasks, ...secondary.tasks.filter(t => !taskIds.has(t.id))],
+    sessions: [...primary.sessions, ...secondary.sessions.filter(s => !sessionIds.has(s.id))],
+    updatedAt: new Date().toISOString(),
   };
 }
 


### PR DESCRIPTION
## Root cause

Every sync operation (`loadFromDynamo` on mount and `manualSync`) called `dispatch({ type: 'LOAD_STATE', payload: remote })`, which **completely replaced** the entire in-memory state with whatever came back from DynamoDB. Three scenarios caused data loss:

1. **Mount race**: Tasks added in the ~1–3 s window while DynamoDB is loading were overwritten when the response arrived (localStorage wasn't updated during this window, so `loadState()` in the callback was stale).
2. **Multi-device conflict**: Two devices write their full state to the same DynamoDB record independently. Last write wins; the earlier device's new tasks are erased on next sync.
3. **Manual sync race**: Pending debounce timer could write old state to DynamoDB after a manual sync loaded newer remote state.

## Fix

- **`src/types/index.ts`**: Added `updatedAt?: string` to `AppState` for conflict resolution.
- **`src/context/reducer.ts`**: All 7 mutating actions now stamp `updatedAt: new Date().toISOString()` so every local change is timestamped.
- **`src/utils/storage.ts`**: Added `mergeStates(local, remote)` — the newer source (by `updatedAt`) wins for settings/task state, but tasks and sessions from both sources are **always union-merged** so no task is ever dropped. Legacy data (no `updatedAt`) defaults to local-wins.
- **`src/context/AppContext.tsx`**:
  - Save effect now **always** writes to localStorage (only DynamoDB is guarded), so `loadState()` inside async callbacks always reflects the live state — closing the mount race.
  - Initial load and `manualSync` now call `mergeStates()` instead of blind replace.
  - `manualSync` cancels any pending debounce write before loading, then immediately pushes the merged result.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)