### PR TITLE
[bug] Message between Start/Pause button and task name is not correct

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -21,6 +21,10 @@ const en = {
     noTaskSelected: 'No task selected',
     selectTask: 'Select a task to focus on',
     pomodorosToday: (n: number) => `${n} pomodoro${n !== 1 ? 's' : ''} today`,
+    queueMessage: (tasks: number, pomodoros: number) => {
+      const motivation = pomodoros >= 9 ? 'Work hard!' : pomodoros >= 4 ? 'Keep it up!' : 'Easy day.';
+      return `You have ${tasks} task${tasks !== 1 ? 's' : ''}, ${pomodoros} pomodoro${pomodoros !== 1 ? 's' : ''} to go. ${motivation}`;
+    },
     forceComplete: 'Done',
     confirmSwitchMode: 'Timer is running. Switch mode and lose current session progress?',
     confirmSwitchTask: 'Timer is running. Switch to this task?',
@@ -123,6 +127,10 @@ const ja: typeof en = {
     noTaskSelected: 'タスク未選択',
     selectTask: '集中するタスクを選択してください',
     pomodorosToday: (n: number) => `今日${n}ポモドーロ`,
+    queueMessage: (tasks: number, pomodoros: number) => {
+      const motivation = pomodoros >= 9 ? '頑張れ！' : pomodoros >= 4 ? '継続は力なり！' : '余裕の一日。';
+      return `残り${tasks}タスク、${pomodoros}ポモドーロです。${motivation}`;
+    },
     forceComplete: '完了',
     confirmSwitchMode: 'タイマーが動作中です。モードを切り替えて現在のセッションを破棄しますか？',
     confirmSwitchTask: 'タイマーが動作中です。このタスクに切り替えますか？',

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -47,6 +47,11 @@ export function TimerPage() {
   const hasCompleted = todayTasks.some(t => t.completed);
   const needsTaskHint = timer.mode === 'focus' && !timer.activeTaskId && !timer.running;
   const todaySessions = state.sessions.filter(s => s.date === today && s.type === 'focus' && s.completed);
+  const pendingTasks = todayTasks.filter(t => !t.completed);
+  const pendingPomodoros = pendingTasks.reduce(
+    (sum, t) => sum + Math.max(0, t.estimatedPomodoros - t.completedPomodoros),
+    0
+  );
   const bgGradient = BG_COLORS[timer.mode] ?? BG_COLORS.focus;
 
   function handleSwitchMode(newMode: TimerMode) {
@@ -105,6 +110,11 @@ export function TimerPage() {
           />
           {needsTaskHint && (
             <p className="text-white/50 text-xs">{t.timer.selectTask}</p>
+          )}
+          {pendingTasks.length > 0 && (
+            <p className="text-white/60 text-xs text-center">
+              {t.timer.queueMessage(pendingTasks.length, pendingPomodoros)}
+            </p>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

- Added `queueMessage` translation function (en + ja) that shows the number of pending tasks and remaining pomodoros with a motivational tone
- Message scales: ≥9 pomodoros → "Work hard!" / ≥4 → "Keep it up!" / <4 → "Easy day."
- Displayed below the timer controls, above the active task name, whenever there are pending (incomplete) tasks

## Test plan

- [ ] Add a few tasks with estimated pomodoros; verify the queue message appears below the Start/Pause button
- [ ] Complete some pomodoros on a task; verify the remaining count decrements correctly
- [ ] Complete all tasks; verify the message disappears
- [ ] Switch language to Japanese; verify the Japanese message and motivational text render correctly
- [ ] Confirm the message threshold logic: ≥9 pomodoros shows "Work hard!", 4-8 shows "Keep it up!", ≤3 shows "Easy day."

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)