### PR TITLE
Fix empty DynamoDB overwrite + sync debug log page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { TopBar } from './components/layout/TopBar';
 import { TimerPage } from './pages/TimerPage';
 import { ReportsPage } from './pages/ReportsPage';
 import { SettingsPage } from './pages/SettingsPage';
+import { DebugPage } from './pages/DebugPage';
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
                     <Route path="/" element={<TimerPage />} />
                     <Route path="/reports" element={<ReportsPage />} />
                     <Route path="/settings" element={<SettingsPage />} />
+                    <Route path="/debug" element={<DebugPage />} />
                   </Routes>
                 </main>
               </div>

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -13,6 +13,7 @@ export function TopBar() {
     { to: '/', label: t.nav.timer },
     { to: '/reports', label: t.nav.reports },
     { to: '/settings', label: t.nav.settings },
+    { to: '/debug', label: 'Debug' },
   ];
 
   return (

--- a/src/pages/DebugPage.tsx
+++ b/src/pages/DebugPage.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { readSyncLog, clearSyncLog } from '../utils/syncLog';
+
+export function DebugPage() {
+  const [entries, setEntries] = useState(() => readSyncLog().reverse());
+
+  function handleClear() {
+    clearSyncLog();
+    setEntries([]);
+  }
+
+  function handleRefresh() {
+    setEntries(readSyncLog().reverse());
+  }
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: '16px', fontSize: '12px' }}>
+      <h2 style={{ marginBottom: '8px' }}>Sync Debug Log</h2>
+      <div style={{ marginBottom: '12px', display: 'flex', gap: '8px' }}>
+        <button onClick={handleRefresh} style={{ padding: '4px 10px', cursor: 'pointer' }}>Refresh</button>
+        <button onClick={handleClear} style={{ padding: '4px 10px', cursor: 'pointer', color: 'red' }}>Clear log</button>
+        <span style={{ color: '#666' }}>{entries.length} entries (newest first)</span>
+      </div>
+      {entries.length === 0 ? (
+        <p style={{ color: '#999' }}>No log entries yet. Interact with the app to generate events.</p>
+      ) : (
+        <table style={{ borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr style={{ background: '#f0f0f0' }}>
+              <th style={{ textAlign: 'left', padding: '4px 8px', borderBottom: '1px solid #ccc' }}>Timestamp</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px', borderBottom: '1px solid #ccc' }}>Event</th>
+              <th style={{ textAlign: 'left', padding: '4px 8px', borderBottom: '1px solid #ccc' }}>Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, i) => (
+              <tr key={i} style={{ background: e.event.includes('error') || e.event.includes('blocked') ? '#fff0f0' : i % 2 === 0 ? '#fff' : '#fafafa' }}>
+                <td style={{ padding: '3px 8px', borderBottom: '1px solid #eee', whiteSpace: 'nowrap' }}>{e.ts}</td>
+                <td style={{ padding: '3px 8px', borderBottom: '1px solid #eee', whiteSpace: 'nowrap', fontWeight: e.event.includes('error') || e.event.includes('blocked') ? 'bold' : 'normal', color: e.event.includes('error') || e.event.includes('blocked') ? 'red' : 'inherit' }}>{e.event}</td>
+                <td style={{ padding: '3px 8px', borderBottom: '1px solid #eee', color: '#555' }}>{e.detail ?? ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/utils/dynamoSync.ts
+++ b/src/utils/dynamoSync.ts
@@ -2,6 +2,7 @@ import { fetchAuthSession } from 'aws-amplify/auth';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
 import type { AppState } from '../types';
+import { logSync } from './syncLog';
 
 const REGION = 'ap-northeast-1';
 const TABLE = 'MyTask';
@@ -38,9 +39,13 @@ export async function loadFromDynamo(): Promise<DynamoLoadResult> {
     const state = res.Item?.data
       ? JSON.parse(res.Item.data as string) as AppState
       : null;
+    logSync('loadFromDynamo', state
+      ? `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`
+      : 'no data in DynamoDB');
     return { state, identityId };
   } catch (err) {
     console.error('DynamoDB load error:', err);
+    logSync('loadFromDynamo:error', String(err));
     return { state: null, identityId: null };
   }
 }
@@ -48,6 +53,24 @@ export async function loadFromDynamo(): Promise<DynamoLoadResult> {
 export async function saveToDynamo(state: AppState): Promise<void> {
   try {
     const { client, identityId } = await getSession();
+
+    // Guard: refuse to overwrite existing non-empty data with an empty state
+    if (state.tasks.length === 0 && state.sessions.length === 0) {
+      const existing = await client.send(new GetCommand({
+        TableName: TABLE,
+        Key: { userId: identityId, sk: SK },
+      }));
+      if (existing.Item?.data) {
+        const existingState = JSON.parse(existing.Item.data as string) as AppState;
+        if (existingState.tasks.length > 0 || existingState.sessions.length > 0) {
+          logSync('saveToDynamo:blocked', `refused to overwrite dynamo (tasks=${existingState.tasks.length}) with empty state`);
+          console.warn('saveToDynamo: blocked empty-state overwrite of existing data');
+          return;
+        }
+      }
+    }
+
+    logSync('saveToDynamo', `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`);
     await client.send(new PutCommand({
       TableName: TABLE,
       Item: {
@@ -59,5 +82,6 @@ export async function saveToDynamo(state: AppState): Promise<void> {
     }));
   } catch (err) {
     console.error('DynamoDB save error:', err);
+    logSync('saveToDynamo:error', String(err));
   }
 }

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { defaultAppState, mergeStates } from './storage';
+import type { AppState, Task } from '../types';
+
+// syncLog writes to localStorage — stub it out
+vi.mock('./syncLog', () => ({ logSync: vi.fn() }));
+
+const EPOCH = new Date(0).toISOString();
+
+function makeTask(id: string): Task {
+  return {
+    id,
+    title: `Task ${id}`,
+    estimatedPomodoros: 1,
+    completedPomodoros: 0,
+    date: '2026-01-01',
+    completed: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeState(tasks: Task[], updatedAt: string): AppState {
+  return {
+    tasks,
+    sessions: [],
+    settings: {
+      focusDuration: 25,
+      shortBreakDuration: 5,
+      longBreakDuration: 15,
+      longBreakInterval: 4,
+      autoStartBreaks: false,
+      autoStartPomodoros: false,
+      soundEnabled: true,
+    },
+    selectedDate: '2026-01-01',
+    updatedAt,
+  };
+}
+
+describe('defaultAppState', () => {
+  it('has epoch updatedAt so it always loses to real data in mergeStates', () => {
+    expect(defaultAppState().updatedAt).toBe(EPOCH);
+  });
+
+  it('has empty tasks and sessions', () => {
+    const s = defaultAppState();
+    expect(s.tasks).toHaveLength(0);
+    expect(s.sessions).toHaveLength(0);
+  });
+});
+
+describe('mergeStates', () => {
+  beforeEach(() => {
+    // localStorage needed for logSync (mocked but storage.ts still calls it)
+    vi.stubGlobal('localStorage', {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+  });
+
+  it('remote wins when remote.updatedAt is newer', () => {
+    const local = makeState([makeTask('a')], '2026-01-01T10:00:00.000Z');
+    const remote = makeState([makeTask('b')], '2026-01-02T10:00:00.000Z');
+    const merged = mergeStates(local, remote);
+    // remote is primary — task b is in primary
+    expect(merged.tasks.find(t => t.id === 'b')).toBeDefined();
+    // task a from local (secondary) union-merged in
+    expect(merged.tasks.find(t => t.id === 'a')).toBeDefined();
+  });
+
+  it('local wins when local.updatedAt is newer', () => {
+    const local = makeState([makeTask('a')], '2026-01-02T10:00:00.000Z');
+    const remote = makeState([makeTask('b')], '2026-01-01T10:00:00.000Z');
+    const merged = mergeStates(local, remote);
+    expect(merged.tasks.find(t => t.id === 'a')).toBeDefined();
+    expect(merged.tasks.find(t => t.id === 'b')).toBeDefined();
+  });
+
+  it('empty default state (epoch) loses to real remote data', () => {
+    const local = makeState([], EPOCH); // defaultAppState scenario
+    const remote = makeState([makeTask('x'), makeTask('y')], '2026-03-01T00:00:00.000Z');
+    const merged = mergeStates(local, remote);
+    // remote should win as primary
+    expect(merged.tasks).toHaveLength(2);
+    expect(merged.tasks.find(t => t.id === 'x')).toBeDefined();
+    expect(merged.tasks.find(t => t.id === 'y')).toBeDefined();
+  });
+
+  it('union-merges tasks from both sides — no task is lost', () => {
+    const local = makeState([makeTask('a'), makeTask('b')], '2026-01-02T00:00:00.000Z');
+    const remote = makeState([makeTask('b'), makeTask('c')], '2026-01-01T00:00:00.000Z');
+    const merged = mergeStates(local, remote);
+    const ids = merged.tasks.map(t => t.id).sort();
+    expect(ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not duplicate tasks present in both sides', () => {
+    const task = makeTask('shared');
+    const local = makeState([task], '2026-01-02T00:00:00.000Z');
+    const remote = makeState([task], '2026-01-01T00:00:00.000Z');
+    const merged = mergeStates(local, remote);
+    expect(merged.tasks.filter(t => t.id === 'shared')).toHaveLength(1);
+  });
+});

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,6 @@
 import type { AppState } from '../types';
 import { DEFAULT_SETTINGS } from '../constants/defaults';
+import { logSync } from './syncLog';
 
 const STATE_KEY = 'mytask_state';
 const IDENTITY_KEY = 'mytask_identity';
@@ -14,7 +15,7 @@ export function defaultAppState(): AppState {
     sessions: [],
     settings: { ...DEFAULT_SETTINGS },
     selectedDate: todayStr(),
-    updatedAt: new Date().toISOString(),
+    updatedAt: new Date(0).toISOString(), // epoch — always loses to real data in mergeStates
   };
 }
 
@@ -29,9 +30,18 @@ export function mergeStates(local: AppState, remote: AppState): AppState {
   const taskIds = new Set(primary.tasks.map(t => t.id));
   const sessionIds = new Set(primary.sessions.map(s => s.id));
 
+  const mergedFromSecondary = secondary.tasks.filter(t => !taskIds.has(t.id));
+  logSync(
+    'mergeStates',
+    `winner=${remoteNewer ? 'remote' : 'local'} ` +
+    `primary.tasks=${primary.tasks.length} secondary.tasks=${secondary.tasks.length} ` +
+    `merged_in=${mergedFromSecondary.length} ` +
+    `local.updatedAt=${local.updatedAt ?? 'none'} remote.updatedAt=${remote.updatedAt ?? 'none'}`
+  );
+
   return {
     ...primary,
-    tasks: [...primary.tasks, ...secondary.tasks.filter(t => !taskIds.has(t.id))],
+    tasks: [...primary.tasks, ...mergedFromSecondary],
     sessions: [...primary.sessions, ...secondary.sessions.filter(s => !sessionIds.has(s.id))],
     updatedAt: new Date().toISOString(),
   };

--- a/src/utils/syncLog.ts
+++ b/src/utils/syncLog.ts
@@ -1,0 +1,33 @@
+const LOG_KEY = 'mytask_sync_log';
+const MAX_ENTRIES = 200;
+
+export interface SyncLogEntry {
+  ts: string;
+  event: string;
+  detail?: string;
+}
+
+export function logSync(event: string, detail?: string): void {
+  try {
+    const raw = localStorage.getItem(LOG_KEY);
+    const entries: SyncLogEntry[] = raw ? JSON.parse(raw) : [];
+    entries.push({ ts: new Date().toISOString(), event, detail });
+    if (entries.length > MAX_ENTRIES) entries.splice(0, entries.length - MAX_ENTRIES);
+    localStorage.setItem(LOG_KEY, JSON.stringify(entries));
+  } catch {
+    // never throw from a logger
+  }
+}
+
+export function readSyncLog(): SyncLogEntry[] {
+  try {
+    const raw = localStorage.getItem(LOG_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function clearSyncLog(): void {
+  localStorage.removeItem(LOG_KEY);
+}


### PR DESCRIPTION
## Summary
- `defaultAppState()` now uses epoch `updatedAt` (`1970-01-01T00:00:00.000Z`) instead of `Date.now()`, so it always loses to real DynamoDB data in `mergeStates` comparisons — fixing the root cause where a fresh browser session could silently shadow real data
- `saveToDynamo` now guards against overwriting non-empty DynamoDB with empty state (read-before-write when `tasks.length === 0 && sessions.length === 0`)
- New `syncLog` utility logs all key sync events (load, save, merge, guard-block) to `localStorage` (last 200 entries)
- New `/debug` page displays the sync log in reverse-chronological order with Refresh and Clear buttons
- `mergeStates` logs which side won and how many tasks were merged from the secondary source
- 7 new unit tests covering `defaultAppState` epoch timestamp and `mergeStates` behavior

## Test plan
- [ ] `npm test -- --run` passes (12 tests)
- [ ] `npm run build` passes
- [ ] Open app → navigate to Debug tab → verify sync events appear after load
- [ ] `saveToDynamo:blocked` event appears in log if empty state would have overwritten data

🤖 Generated with [Claude Code](https://claude.com/claude-code)