### PR TITLE
画面に登録したタスクが突然消えてしまう

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -3,6 +3,7 @@ import type { AppState, Task, Session, Settings } from '../types';
 import { appReducer } from './reducer';
 import { loadState, saveState, loadStoredIdentity, saveIdentity, defaultAppState, mergeStates } from '../utils/storage';
 import { loadFromDynamo, saveToDynamo } from '../utils/dynamoSync';
+import { logSync } from '../utils/syncLog';
 
 interface AppContextValue {
   state: AppState;
@@ -26,6 +27,8 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [syncing, setSyncing] = useState(true);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadingFromRemote = useRef(false);
+  const syncedTaskIdsRef = useRef<Set<string>>(new Set());
+  const prevTaskCountRef = useRef<number>(state.tasks.length);
 
   useEffect(() => {
     setSyncing(true);
@@ -39,12 +42,17 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
         dispatch({ type: 'LOAD_STATE', payload: fresh });
         saveState(fresh);
         saveIdentity(identityId);
+        syncedTaskIdsRef.current = new Set(fresh.tasks.map(t => t.id));
       } else if (remote) {
         const local = loadState();
         const merged = mergeStates(local, remote);
         dispatch({ type: 'LOAD_STATE', payload: merged });
         saveState(merged);
         if (identityId) saveIdentity(identityId);
+        syncedTaskIdsRef.current = new Set(merged.tasks.map(t => t.id));
+        logSync('hydrate:complete',
+          `dynamo.tasks=${remote.tasks.length} local.tasks=${local.tasks.length} merged.tasks=${merged.tasks.length}`
+        );
       } else if (identityId) {
         saveIdentity(identityId);
       }
@@ -56,10 +64,30 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     saveState(state);                        // always keep localStorage current
+
+    // Log state change with sync metrics
+    const unsyncedCount = state.tasks.filter(t => !syncedTaskIdsRef.current.has(t.id)).length;
+    const todayTasks = state.tasks.filter(t => t.date === state.selectedDate).length;
+    logSync('stateChange',
+      `tasks=${state.tasks.length} todayTasks=${todayTasks} unsynced=${unsyncedCount} selectedDate=${state.selectedDate}`
+    );
+
+    // Warn on bulk task drop (2+ tasks disappear at once)
+    const dropped = prevTaskCountRef.current - state.tasks.length;
+    if (dropped >= 2) {
+      logSync('tasks:bulk-drop:warning',
+        `tasks dropped from ${prevTaskCountRef.current} to ${state.tasks.length} ` +
+        `remaining_ids=[${state.tasks.map(t => t.id).join(',')}]`
+      );
+      console.warn('tasks:bulk-drop', { dropped, prevCount: prevTaskCountRef.current, currentCount: state.tasks.length, tasks: state.tasks });
+    }
+    prevTaskCountRef.current = state.tasks.length;
+
     if (loadingFromRemote.current) return;   // guard only the DynamoDB write
     if (saveTimer.current) clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(() => {
-      saveToDynamo(state);
+    saveTimer.current = setTimeout(async () => {
+      await saveToDynamo(state);
+      syncedTaskIdsRef.current = new Set(state.tasks.map(t => t.id));
     }, 1500);
     return () => { if (saveTimer.current) clearTimeout(saveTimer.current); };
   }, [state]);
@@ -75,6 +103,10 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       saveState(merged);
       if (identityId) saveIdentity(identityId);
       await saveToDynamo(merged); // push merged state immediately
+      syncedTaskIdsRef.current = new Set(merged.tasks.map(t => t.id));
+      logSync('manualSync:complete',
+        `dynamo.tasks=${remote.tasks.length} local.tasks=${local.tasks.length} merged.tasks=${merged.tasks.length}`
+      );
     }
     setSyncing(false);
   }

--- a/src/utils/dynamoSync.test.ts
+++ b/src/utils/dynamoSync.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { loadFromDynamo, saveToDynamo, isCredentialError } from './dynamoSync';
+import type { AppState } from '../types';
+
+// Mock modules
+vi.mock('./syncLog', () => ({ logSync: vi.fn() }));
+
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({ send: mockSend })),
+  },
+  // Use regular functions (not arrow functions) so `new Command(...)` works
+  GetCommand: vi.fn(function (this: Record<string, unknown>, input: unknown) {
+    this.input = input;
+  }),
+  PutCommand: vi.fn(function (this: Record<string, unknown>, input: unknown) {
+    this.input = input;
+  }),
+}));
+
+vi.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: vi.fn(function () {}),
+}));
+
+const mockFetchAuthSession = vi.fn();
+vi.mock('aws-amplify/auth', () => ({
+  fetchAuthSession: (...args: unknown[]) => mockFetchAuthSession(...args),
+}));
+
+function makeSession() {
+  return {
+    credentials: {
+      accessKeyId: 'key',
+      secretAccessKey: 'secret',
+      sessionToken: 'token',
+    },
+    identityId: 'user-123',
+  };
+}
+
+function makeState(taskCount = 2): AppState {
+  return {
+    tasks: Array.from({ length: taskCount }, (_, i) => ({
+      id: `task-${i}`,
+      title: `Task ${i}`,
+      estimatedPomodoros: 1,
+      completedPomodoros: 0,
+      date: '2026-01-01',
+      completed: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })),
+    sessions: [],
+    settings: {
+      focusDuration: 25,
+      shortBreakDuration: 5,
+      longBreakDuration: 15,
+      longBreakInterval: 4,
+      autoStartBreaks: false,
+      autoStartPomodoros: false,
+      soundEnabled: true,
+    },
+    selectedDate: '2026-01-01',
+    updatedAt: '2026-01-01T10:00:00.000Z',
+  };
+}
+
+function makeCredentialError(name: string) {
+  const err = new Error(`${name}: token expired`);
+  err.name = name;
+  return err;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFetchAuthSession.mockResolvedValue(makeSession());
+});
+
+// ─── isCredentialError ────────────────────────────────────────────────────────
+
+describe('isCredentialError', () => {
+  it('returns true for NotAuthorizedException', () => {
+    expect(isCredentialError(makeCredentialError('NotAuthorizedException'))).toBe(true);
+  });
+
+  it('returns true for InvalidSignatureException', () => {
+    expect(isCredentialError(makeCredentialError('InvalidSignatureException'))).toBe(true);
+  });
+
+  it('returns true for ExpiredTokenException', () => {
+    expect(isCredentialError(makeCredentialError('ExpiredTokenException'))).toBe(true);
+  });
+
+  it('returns false for NetworkError', () => {
+    const err = new Error('NetworkError: A network error has occurred');
+    err.name = 'NetworkError';
+    expect(isCredentialError(err)).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isCredentialError(null)).toBe(false);
+    expect(isCredentialError(undefined)).toBe(false);
+  });
+});
+
+// ─── loadFromDynamo ───────────────────────────────────────────────────────────
+
+describe('loadFromDynamo', () => {
+  it('returns state and identityId on success', async () => {
+    const state = makeState(3);
+    mockSend.mockResolvedValueOnce({ Item: { data: JSON.stringify(state) } });
+
+    const result = await loadFromDynamo();
+
+    expect(result.identityId).toBe('user-123');
+    expect(result.state?.tasks).toHaveLength(3);
+  });
+
+  it('returns null state when DynamoDB item has no data', async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined });
+
+    const result = await loadFromDynamo();
+
+    expect(result.state).toBeNull();
+    expect(result.identityId).toBe('user-123');
+  });
+
+  it('retries with forceRefresh on credential error and succeeds', async () => {
+    const state = makeState(2);
+    // First getSession → credential error; second getSession (forceRefresh) → success
+    mockFetchAuthSession
+      .mockRejectedValueOnce(makeCredentialError('NotAuthorizedException'))
+      .mockResolvedValueOnce(makeSession());
+    mockSend.mockResolvedValueOnce({ Item: { data: JSON.stringify(state) } });
+
+    const result = await loadFromDynamo();
+
+    expect(mockFetchAuthSession).toHaveBeenCalledTimes(2);
+    expect(mockFetchAuthSession).toHaveBeenLastCalledWith({ forceRefresh: true });
+    expect(result.state?.tasks).toHaveLength(2);
+  });
+
+  it('returns null/null if retry also fails', async () => {
+    mockFetchAuthSession
+      .mockRejectedValueOnce(makeCredentialError('NotAuthorizedException'))
+      .mockRejectedValueOnce(makeCredentialError('NotAuthorizedException'));
+
+    const result = await loadFromDynamo();
+
+    expect(result.state).toBeNull();
+    expect(result.identityId).toBeNull();
+  });
+
+  it('does not retry on non-credential errors', async () => {
+    const networkErr = new Error('NetworkError: A network error has occurred');
+    networkErr.name = 'NetworkError';
+    mockFetchAuthSession.mockRejectedValueOnce(networkErr);
+
+    const result = await loadFromDynamo();
+
+    expect(mockFetchAuthSession).toHaveBeenCalledTimes(1);
+    expect(result.state).toBeNull();
+    expect(result.identityId).toBeNull();
+  });
+});
+
+// ─── saveToDynamo ─────────────────────────────────────────────────────────────
+
+describe('saveToDynamo', () => {
+  it('saves state to DynamoDB successfully', async () => {
+    const state = makeState(2);
+    mockSend.mockResolvedValueOnce({});
+
+    await saveToDynamo(state);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries with forceRefresh on credential error and succeeds', async () => {
+    const state = makeState(2);
+    mockFetchAuthSession
+      .mockRejectedValueOnce(makeCredentialError('InvalidSignatureException'))
+      .mockResolvedValueOnce(makeSession());
+    mockSend.mockResolvedValueOnce({});
+
+    await saveToDynamo(state);
+
+    expect(mockFetchAuthSession).toHaveBeenCalledTimes(2);
+    expect(mockFetchAuthSession).toHaveBeenLastCalledWith({ forceRefresh: true });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on non-credential errors', async () => {
+    const state = makeState(2);
+    const networkErr = new Error('NetworkError: A network error has occurred');
+    networkErr.name = 'NetworkError';
+    mockFetchAuthSession.mockRejectedValueOnce(networkErr);
+
+    await saveToDynamo(state); // should not throw
+
+    expect(mockFetchAuthSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks empty-state overwrite when DynamoDB has existing data', async () => {
+    const existingState = makeState(3);
+    const emptyState = makeState(0);
+    // GetCommand returns existing non-empty data
+    mockSend.mockResolvedValueOnce({ Item: { data: JSON.stringify(existingState) } });
+
+    await saveToDynamo(emptyState);
+
+    // Only 1 send call (the guard GetCommand), PutCommand NOT called
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/dynamoSync.ts
+++ b/src/utils/dynamoSync.ts
@@ -13,8 +13,8 @@ interface SessionData {
   identityId: string;
 }
 
-async function getSession(): Promise<SessionData> {
-  const session = await fetchAuthSession();
+async function getSession(forceRefresh = false): Promise<SessionData> {
+  const session = await fetchAuthSession({ forceRefresh });
   const { accessKeyId, secretAccessKey, sessionToken } = session.credentials!;
   const identityId = session.identityId!;
   const raw = new DynamoDBClient({
@@ -24,6 +24,33 @@ async function getSession(): Promise<SessionData> {
   return { client: DynamoDBDocumentClient.from(raw), identityId };
 }
 
+export function isCredentialError(err: unknown): boolean {
+  if (!err) return false;
+  const name = (err as { name?: string }).name ?? '';
+  const msg = String(err);
+  return (
+    name === 'NotAuthorizedException' ||
+    name === 'InvalidSignatureException' ||
+    name === 'ExpiredTokenException' ||
+    name === 'UnauthorizedException' ||
+    msg.includes('expired') ||
+    msg.includes('credentials') ||
+    msg.includes('Signature')
+  );
+}
+
+async function attemptWithRetry<T>(fn: (session: SessionData) => Promise<T>): Promise<T> {
+  try {
+    const session = await getSession();
+    return await fn(session);
+  } catch (err) {
+    if (!isCredentialError(err)) throw err;
+    logSync('dynamoSync:credential-error', `retrying with forceRefresh: ${String(err)}`);
+    const session = await getSession(true);
+    return await fn(session);
+  }
+}
+
 export interface DynamoLoadResult {
   state: AppState | null;
   identityId: string | null;
@@ -31,18 +58,19 @@ export interface DynamoLoadResult {
 
 export async function loadFromDynamo(): Promise<DynamoLoadResult> {
   try {
-    const { client, identityId } = await getSession();
-    const res = await client.send(new GetCommand({
-      TableName: TABLE,
-      Key: { userId: identityId, sk: SK },
-    }));
-    const state = res.Item?.data
-      ? JSON.parse(res.Item.data as string) as AppState
-      : null;
-    logSync('loadFromDynamo', state
-      ? `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`
-      : 'no data in DynamoDB');
-    return { state, identityId };
+    return await attemptWithRetry(async ({ client, identityId }) => {
+      const res = await client.send(new GetCommand({
+        TableName: TABLE,
+        Key: { userId: identityId, sk: SK },
+      }));
+      const state = res.Item?.data
+        ? JSON.parse(res.Item.data as string) as AppState
+        : null;
+      logSync('loadFromDynamo', state
+        ? `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`
+        : 'no data in DynamoDB');
+      return { state, identityId };
+    });
   } catch (err) {
     console.error('DynamoDB load error:', err);
     logSync('loadFromDynamo:error', String(err));
@@ -52,34 +80,35 @@ export async function loadFromDynamo(): Promise<DynamoLoadResult> {
 
 export async function saveToDynamo(state: AppState): Promise<void> {
   try {
-    const { client, identityId } = await getSession();
-
-    // Guard: refuse to overwrite existing non-empty data with an empty state
-    if (state.tasks.length === 0 && state.sessions.length === 0) {
-      const existing = await client.send(new GetCommand({
-        TableName: TABLE,
-        Key: { userId: identityId, sk: SK },
-      }));
-      if (existing.Item?.data) {
-        const existingState = JSON.parse(existing.Item.data as string) as AppState;
-        if (existingState.tasks.length > 0 || existingState.sessions.length > 0) {
-          logSync('saveToDynamo:blocked', `refused to overwrite dynamo (tasks=${existingState.tasks.length}) with empty state`);
-          console.warn('saveToDynamo: blocked empty-state overwrite of existing data');
-          return;
+    await attemptWithRetry(async ({ client, identityId }) => {
+      // Guard: refuse to overwrite existing non-empty data with an empty state
+      if (state.tasks.length === 0 && state.sessions.length === 0) {
+        const existing = await client.send(new GetCommand({
+          TableName: TABLE,
+          Key: { userId: identityId, sk: SK },
+        }));
+        if (existing.Item?.data) {
+          const existingState = JSON.parse(existing.Item.data as string) as AppState;
+          if (existingState.tasks.length > 0 || existingState.sessions.length > 0) {
+            logSync('saveToDynamo:blocked', `refused to overwrite dynamo (tasks=${existingState.tasks.length}) with empty state`);
+            console.warn('saveToDynamo: blocked empty-state overwrite of existing data');
+            return;
+          }
         }
       }
-    }
 
-    logSync('saveToDynamo', `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`);
-    await client.send(new PutCommand({
-      TableName: TABLE,
-      Item: {
-        userId: identityId,
-        sk: SK,
-        data: JSON.stringify(state),
-        updatedAt: new Date().toISOString(),
-      },
-    }));
+      logSync('saveToDynamo', `tasks=${state.tasks.length} sessions=${state.sessions.length} updatedAt=${state.updatedAt ?? 'none'}`);
+      await client.send(new PutCommand({
+        TableName: TABLE,
+        Item: {
+          userId: identityId,
+          sk: SK,
+          data: JSON.stringify(state),
+          updatedAt: new Date().toISOString(),
+        },
+      }));
+      logSync('saveToDynamo:success', `tasks=${state.tasks.length} sessions=${state.sessions.length}`);
+    });
   } catch (err) {
     console.error('DynamoDB save error:', err);
     logSync('saveToDynamo:error', String(err));


### PR DESCRIPTION
## Summary

- **Root fix**: Add credential retry logic in `dynamoSync.ts` — when DynamoDB operations fail with `NotAuthorizedException`, `InvalidSignatureException`, or `ExpiredTokenException` (expired Cognito credentials after Mac sleep), the code now force-refreshes the Amplify session and retries once instead of silently failing.
- **Richer debug logging**: `AppContext` now tracks synced task IDs and logs `stateChange` entries on every state update with `tasks=N todayTasks=M unsynced=K` counts; `hydrate:complete` and `manualSync:complete` log entries show dynamo/local/merged task counts.
- **Bulk-drop warning**: Emits `tasks:bulk-drop:warning` log + `console.warn` whenever 2+ tasks disappear in a single state transition.
- **Tests**: Added `src/utils/dynamoSync.test.ts` covering retry on credential errors, no-retry on network errors, and the empty-state overwrite guard.

Closes #20