### PR TITLE
[bug] Fix report filter to use session dates instead of task planned dates

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -181,7 +181,7 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | RPT-9  | The reports page shows a filterable history table of completed and archived tasks.                            |
 | RPT-10 | Each row shows: title, pomodoro count (completed/estimated), started timestamp, completed/archived timestamp. |
 | RPT-11 | Archived tasks are shown at 50% opacity to distinguish them from completed tasks.                             |
-| RPT-12 | A date range filter (From / To) placed above the focus distribution chart applies to **both** the focus distribution chart and the task history table. Both pickers default to today so only the current day's data is shown on first open. |
+| RPT-12 | A date range filter (From / To) placed above the focus distribution chart applies to **both** the focus distribution chart and the task history table. Both pickers default to today so only the current day's data is shown on first open. The date filter matches tasks by **when focus sessions occurred** (session date), not by the task's planned date — so a task planned on day X but worked on day Y appears in day Y's report. |
 | RPT-13 | A clear-filter button (✕) removes the date filter when a range is active.                                                                             |
 | RPT-14 | If no task history exists for the selected range, a "No task history" message is shown.                       |
 | RPT-15 | The reports page shows an **Interruptions** section filtered by the same date range as task history. Each row shows the reason (or "(no reason given)"), the timestamp, and the linked task name if available. |

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -6,6 +6,7 @@ import {
 import { useApp } from '../hooks/useApp';
 import { useLang } from '../hooks/useLang';
 import { todayStr, getLast7Days, getLast30Days, shortDate, formatMinutes, formatDateTime } from '../utils/formatters';
+import { filterTasksBySessionDates } from '../utils/reportFilters';
 
 export function ReportsPage() {
   const { state } = useApp();
@@ -81,12 +82,8 @@ export function ReportsPage() {
   }, [state.tasks]);
 
   const filteredHistory = useMemo(() => {
-    return taskHistory.filter(task => {
-      if (fromDate && task.date < fromDate) return false;
-      if (toDate && task.date > toDate) return false;
-      return true;
-    });
-  }, [taskHistory, fromDate, toDate]);
+    return filterTasksBySessionDates(taskHistory, focusSessions, fromDate, toDate, today);
+  }, [taskHistory, focusSessions, fromDate, toDate, today]);
 
   const filteredInterruptions = useMemo(() => {
     return (state.interruptions ?? [])

--- a/src/utils/reportFilters.test.ts
+++ b/src/utils/reportFilters.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { filterTasksBySessionDates } from './reportFilters';
+import type { Task, Session } from '../types';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    title: 'Test Task',
+    estimatedPomodoros: 2,
+    completedPomodoros: 1,
+    date: '2026-02-02',
+    completed: true,
+    createdAt: '2026-02-02T09:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    taskId: 'task-1',
+    date: '2026-02-02',
+    startTime: '2026-02-02T09:00:00.000Z',
+    duration: 25,
+    type: 'focus',
+    completed: true,
+    ...overrides,
+  };
+}
+
+describe('filterTasksBySessionDates', () => {
+  it('shows task when a session falls within the date range (not task.date)', () => {
+    // Task planned on Feb 2, sessions on Feb 3 and Feb 4
+    const task = makeTask({ id: 'a', date: '2026-02-02' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-02-03' }),
+      makeSession({ id: 's2', taskId: 'a', date: '2026-02-04' }),
+    ];
+
+    // Viewing Feb 4 report
+    const result = filterTasksBySessionDates([task], sessions, '2026-02-04', '2026-02-04', '2026-02-04');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('excludes task when no sessions fall within the date range', () => {
+    const task = makeTask({ id: 'a', date: '2026-02-02' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-02-03' }),
+    ];
+
+    // Viewing Feb 5 report — no sessions on that day
+    const result = filterTasksBySessionDates([task], sessions, '2026-02-05', '2026-02-05', '2026-02-05');
+    expect(result).toHaveLength(0);
+  });
+
+  it('includes all tasks that have sessions within a multi-day range', () => {
+    const taskA = makeTask({ id: 'a', date: '2026-02-01' });
+    const taskB = makeTask({ id: 'b', date: '2026-02-01' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-02-03' }),
+      makeSession({ id: 's2', taskId: 'b', date: '2026-02-05' }),
+    ];
+
+    const result = filterTasksBySessionDates([taskA, taskB], sessions, '2026-02-01', '2026-02-07', '2026-02-07');
+    expect(result).toHaveLength(2);
+  });
+
+  it('respects fromDate boundary (excludes sessions before fromDate)', () => {
+    const task = makeTask({ id: 'a', date: '2026-02-01' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-02-02' }),
+      makeSession({ id: 's2', taskId: 'a', date: '2026-02-05' }),
+    ];
+
+    // fromDate = Feb 3, so Feb 2 session is excluded; Feb 5 session qualifies
+    const result = filterTasksBySessionDates([task], sessions, '2026-02-03', '2026-02-07', '2026-02-07');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('respects toDate boundary (excludes sessions after toDate)', () => {
+    const task = makeTask({ id: 'a', date: '2026-02-01' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-02-08' }),
+    ];
+
+    const result = filterTasksBySessionDates([task], sessions, '2026-02-01', '2026-02-07', '2026-02-07');
+    expect(result).toHaveLength(0);
+  });
+
+  it('defaults to today when both fromDate and toDate are empty', () => {
+    const task = makeTask({ id: 'a', date: '2026-02-01' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: 'a', date: '2026-04-12' }), // today
+      makeSession({ id: 's2', taskId: 'a', date: '2026-02-10' }), // not today
+    ];
+
+    const result = filterTasksBySessionDates([task], sessions, '', '', '2026-04-12');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a');
+  });
+
+  it('excludes break sessions (null taskId) from affecting task list', () => {
+    const task = makeTask({ id: 'a', date: '2026-02-01' });
+    const sessions = [
+      makeSession({ id: 's1', taskId: null, date: '2026-02-04' }), // break session
+    ];
+
+    const result = filterTasksBySessionDates([task], sessions, '2026-02-04', '2026-02-04', '2026-02-04');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when there are no tasks', () => {
+    const sessions = [makeSession()];
+    const result = filterTasksBySessionDates([], sessions, '2026-02-02', '2026-02-02', '2026-02-02');
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array when there are no sessions', () => {
+    const task = makeTask({ id: 'a' });
+    const result = filterTasksBySessionDates([task], [], '2026-02-02', '2026-02-02', '2026-02-02');
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/utils/reportFilters.ts
+++ b/src/utils/reportFilters.ts
@@ -1,0 +1,28 @@
+import type { Task, Session } from '../types';
+
+/**
+ * Filter tasks by whether they have focus sessions within the given date range.
+ * Uses session.date (when work happened) rather than task.date (when planned).
+ * When no date filter is set, defaults to sessions on today.
+ */
+export function filterTasksBySessionDates(
+  tasks: Task[],
+  focusSessions: Session[],
+  fromDate: string,
+  toDate: string,
+  today: string,
+): Task[] {
+  const hasDateFilter = fromDate || toDate;
+  const sessionTaskIds = new Set(
+    focusSessions
+      .filter(s => {
+        if (hasDateFilter) {
+          return (!fromDate || s.date >= fromDate) && (!toDate || s.date <= toDate);
+        }
+        return s.date === today;
+      })
+      .map(s => s.taskId)
+      .filter((id): id is string => id !== null),
+  );
+  return tasks.filter(task => sessionTaskIds.has(task.id));
+}


### PR DESCRIPTION
## Summary

- The task history section on the Reports page was filtering tasks by `task.date` (when the task was planned) instead of by when actual work sessions happened
- A task planned on day X but worked on day Y now correctly appears in day Y's report
- Extracted the filtering logic into `src/utils/reportFilters.ts` for testability

## Changes

- `src/utils/reportFilters.ts`: new utility `filterTasksBySessionDates` — filters a task list by whether any focus sessions occurred within the date range
- `src/utils/reportFilters.test.ts`: 8 unit tests covering the happy path, edge cases (null taskId for breaks, boundary dates, empty sessions/tasks, default-to-today when no filter)
- `src/pages/ReportsPage.tsx`: replace the `filteredHistory` useMemo with a call to the new utility
- `REQUIREMENTS.md`: updated RPT-12 to clarify that the date filter matches by session date, not task planned date

Closes #37