### PR TITLE
[feature] add distraction distribution graph

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -171,6 +171,8 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | RPT-6 | A **focus distribution pie chart** shows focus time broken down by task or ticket for the active date range filter (defaults to today when no filter is set). A **By Task / By Ticket** toggle switches the grouping. |
 | RPT-7 | In the pie chart, sessions with no linked task (or tasks with no ticket in ticket view) are grouped as "No Task" / "No Ticket".                          |
 | RPT-8 | If no focus session data exists, charts are replaced by a "No data yet" message.                                                                         |
+| RPT-17 | A **distraction distribution pie chart** is shown directly below the focus distribution chart. It groups interruptions by reason (for the active date range) and displays the count and percentage per reason. |
+| RPT-18 | If no interruptions exist in the selected date range, the distraction distribution chart shows a "No interruptions in this period" message.              |
 
 
 ### 5.3 Task History

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -103,6 +103,9 @@ const en = {
     byTask: 'By Task',
     byTicket: 'By Ticket',
     noTicket: 'No Ticket',
+    distractionDistribution: 'Distraction Distribution',
+    noDistractionData: 'No interruptions in this period.',
+    interruptionCount: (n: number) => `${n}×`,
   },
   settings: {
     title: 'Settings',
@@ -240,6 +243,9 @@ const ja: typeof en = {
     byTask: 'タスク別',
     byTicket: 'チケット別',
     noTicket: 'チケットなし',
+    distractionDistribution: '中断分布',
+    noDistractionData: 'この期間の中断はありません。',
+    interruptionCount: (n: number) => `${n}×`,
   },
   settings: {
     title: '設定',

--- a/src/pages/ReportsPage.tsx
+++ b/src/pages/ReportsPage.tsx
@@ -6,7 +6,7 @@ import {
 import { useApp } from '../hooks/useApp';
 import { useLang } from '../hooks/useLang';
 import { todayStr, getLast7Days, getLast30Days, shortDate, formatMinutes, formatDateTime } from '../utils/formatters';
-import { filterTasksBySessionDates } from '../utils/reportFilters';
+import { filterTasksBySessionDates, groupInterruptionsByReason } from '../utils/reportFilters';
 
 export function ReportsPage() {
   const { state } = useApp();
@@ -106,6 +106,10 @@ export function ReportsPage() {
       })
       .sort((a, b) => b.pausedAt.localeCompare(a.pausedAt));
   }, [state.interruptions, fromDate, toDate]);
+
+  const distractionData = useMemo(() => {
+    return groupInterruptionsByReason(filteredInterruptions, t.reports.noReason);
+  }, [filteredInterruptions, t.reports.noReason]);
 
   const barData = barChartSpan === 'weekly' ? weeklyData : monthlyData;
   const xAxisFontSize = barChartSpan === 'monthly' ? 9 : 11;
@@ -207,6 +211,14 @@ export function ReportsPage() {
           onGroupByChange={setFocusGroupBy}
           byTaskLabel={t.reports.byTask}
           byTicketLabel={t.reports.byTicket}
+        />
+
+        {/* Distraction distribution (filtered by the same date range) */}
+        <DistractionDistributionChart
+          data={distractionData}
+          title={t.reports.distractionDistribution}
+          noDataLabel={t.reports.noDistractionData}
+          countLabel={t.reports.interruptionCount}
         />
 
         {/* Task history (filtered by the same date range) */}
@@ -376,6 +388,89 @@ function FocusDistributionChart({ data, title, noDataLabel, focusGroupBy, onGrou
                     {d.title}
                   </span>
                   <span className="text-gray-400 text-xs shrink-0">{d.minutes} min · {pct}%</span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface DistractionEntry { title: string; count: number }
+
+const DISTRACTION_COLORS = [
+  '#f59e0b', '#f97316', '#ef4444', '#ec4899',
+  '#a855f7', '#3b82f6', '#06b6d4', '#22c55e',
+];
+
+function DistractionDistributionChart({ data, title, noDataLabel, countLabel }: {
+  data: DistractionEntry[];
+  title: string;
+  noDataLabel: string;
+  countLabel: (n: number) => string;
+}) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const total = data.reduce((sum, d) => sum + d.count, 0);
+
+  return (
+    <div className="bg-gray-800 rounded-xl p-5">
+      <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">{title}</h2>
+      {data.length === 0 ? (
+        <p className="text-gray-500 text-sm text-center py-4">{noDataLabel}</p>
+      ) : (
+        <>
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={data}
+                dataKey="count"
+                nameKey="title"
+                cx="50%"
+                cy="50%"
+                outerRadius={90}
+                innerRadius={40}
+                onClick={(_, index) => setActiveIndex(activeIndex === index ? null : index)}
+              >
+                {data.map((_, i) => (
+                  <Cell
+                    key={i}
+                    fill={DISTRACTION_COLORS[i % DISTRACTION_COLORS.length]}
+                    opacity={activeIndex === null || activeIndex === i ? 1 : 0.4}
+                    stroke="transparent"
+                  />
+                ))}
+              </Pie>
+              <Tooltip
+                contentStyle={{ background: '#1f2937', border: 'none', borderRadius: 8 }}
+                labelStyle={{ color: '#f3f4f6' }}
+                formatter={(value, _name, props) => {
+                  const n = Number(value);
+                  const pct = total > 0 ? Math.round((n / total) * 100) : 0;
+                  return [`${countLabel(n)} (${pct}%)`, (props as { payload?: DistractionEntry }).payload?.title ?? ''];
+                }}
+              />
+            </PieChart>
+          </ResponsiveContainer>
+          {/* Legend */}
+          <div className="mt-2 space-y-1.5">
+            {data.map((d, i) => {
+              const pct = total > 0 ? Math.round((d.count / total) * 100) : 0;
+              return (
+                <button
+                  key={i}
+                  onClick={() => setActiveIndex(activeIndex === i ? null : i)}
+                  className="w-full flex items-center gap-2 text-sm text-left"
+                >
+                  <span
+                    className="shrink-0 w-3 h-3 rounded-full"
+                    style={{ backgroundColor: DISTRACTION_COLORS[i % DISTRACTION_COLORS.length] }}
+                  />
+                  <span className={`flex-1 truncate ${activeIndex === null || activeIndex === i ? 'text-gray-200' : 'text-gray-500'}`}>
+                    {d.title}
+                  </span>
+                  <span className="text-gray-400 text-xs shrink-0">{countLabel(d.count)} · {pct}%</span>
                 </button>
               );
             })}

--- a/src/utils/reportFilters.test.ts
+++ b/src/utils/reportFilters.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { filterTasksBySessionDates } from './reportFilters';
-import type { Task, Session } from '../types';
+import { filterTasksBySessionDates, groupInterruptionsByReason } from './reportFilters';
+import type { Task, Session, Interruption } from '../types';
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -121,5 +121,79 @@ describe('filterTasksBySessionDates', () => {
     const task = makeTask({ id: 'a' });
     const result = filterTasksBySessionDates([task], [], '2026-02-02', '2026-02-02', '2026-02-02');
     expect(result).toHaveLength(0);
+  });
+});
+
+describe('groupInterruptionsByReason', () => {
+  function makeInterruption(overrides: Partial<Interruption> = {}): Interruption {
+    return {
+      id: 'int-1',
+      taskId: null,
+      date: '2026-02-02',
+      pausedAt: '2026-02-02T10:00:00.000Z',
+      reason: 'Meeting',
+      ...overrides,
+    };
+  }
+
+  it('returns empty array for no interruptions', () => {
+    expect(groupInterruptionsByReason([], '(no reason)')).toHaveLength(0);
+  });
+
+  it('groups interruptions by reason', () => {
+    const interruptions = [
+      makeInterruption({ id: '1', reason: 'Meeting' }),
+      makeInterruption({ id: '2', reason: 'Meeting' }),
+      makeInterruption({ id: '3', reason: 'Phone call' }),
+    ];
+    const result = groupInterruptionsByReason(interruptions, '(no reason)');
+    expect(result).toHaveLength(2);
+    const meeting = result.find(r => r.title === 'Meeting');
+    const phone = result.find(r => r.title === 'Phone call');
+    expect(meeting?.count).toBe(2);
+    expect(phone?.count).toBe(1);
+  });
+
+  it('groups empty-reason interruptions under the noReasonLabel', () => {
+    const interruptions = [
+      makeInterruption({ id: '1', reason: '' }),
+      makeInterruption({ id: '2', reason: '   ' }), // whitespace-only
+    ];
+    const result = groupInterruptionsByReason(interruptions, '(no reason)');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('(no reason)');
+    expect(result[0].count).toBe(2);
+  });
+
+  it('sorts results by count descending', () => {
+    const interruptions = [
+      makeInterruption({ id: '1', reason: 'Rare' }),
+      makeInterruption({ id: '2', reason: 'Common' }),
+      makeInterruption({ id: '3', reason: 'Common' }),
+      makeInterruption({ id: '4', reason: 'Common' }),
+      makeInterruption({ id: '5', reason: 'Rare' }),
+    ];
+    const result = groupInterruptionsByReason(interruptions, '(no reason)');
+    expect(result[0].title).toBe('Common');
+    expect(result[0].count).toBe(3);
+    expect(result[1].title).toBe('Rare');
+    expect(result[1].count).toBe(2);
+  });
+
+  it('handles a single interruption', () => {
+    const result = groupInterruptionsByReason([makeInterruption()], '(no reason)');
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Meeting');
+    expect(result[0].count).toBe(1);
+  });
+
+  it('trims whitespace from reasons before grouping', () => {
+    const interruptions = [
+      makeInterruption({ id: '1', reason: ' Meeting ' }),
+      makeInterruption({ id: '2', reason: 'Meeting' }),
+    ];
+    const result = groupInterruptionsByReason(interruptions, '(no reason)');
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(2);
   });
 });

--- a/src/utils/reportFilters.ts
+++ b/src/utils/reportFilters.ts
@@ -1,4 +1,4 @@
-import type { Task, Session } from '../types';
+import type { Task, Session, Interruption } from '../types';
 
 /**
  * Filter tasks by whether they have focus sessions within the given date range.
@@ -25,4 +25,23 @@ export function filterTasksBySessionDates(
       .filter((id): id is string => id !== null),
   );
   return tasks.filter(task => sessionTaskIds.has(task.id));
+}
+
+/**
+ * Group interruptions by reason and return them sorted by count descending.
+ * Interruptions with an empty reason are grouped under noReasonLabel.
+ */
+export function groupInterruptionsByReason(
+  interruptions: Interruption[],
+  noReasonLabel: string,
+): { title: string; count: number }[] {
+  if (interruptions.length === 0) return [];
+  const byReason: Record<string, number> = {};
+  for (const i of interruptions) {
+    const key = i.reason.trim() || noReasonLabel;
+    byReason[key] = (byReason[key] ?? 0) + 1;
+  }
+  return Object.entries(byReason)
+    .sort((a, b) => b[1] - a[1])
+    .map(([title, count]) => ({ title, count }));
 }


### PR DESCRIPTION
## Summary

- Added a **Distraction Distribution** pie chart directly below the Focus Distribution chart on the Reports page
- Groups interruptions by reason for the active date range, showing count and percentage per reason
- Uses amber/yellow color palette to visually distinguish it from the red-toned focus chart
- Applies the same From/To date filter as the rest of the reports page
- Shows "No interruptions in this period" when no data exists

## Changes

| File | What changed |
|------|-------------|
| `src/utils/reportFilters.ts` | Added `groupInterruptionsByReason()` utility function |
| `src/utils/reportFilters.test.ts` | 6 unit tests for the new function (empty input, grouping, no-reason fallback, sort order, whitespace trimming) |
| `src/pages/ReportsPage.tsx` | Computed `distractionData` from `filteredInterruptions`; added `DistractionDistributionChart` component; rendered it after the focus distribution chart |
| `src/i18n/translations.ts` | Added `distractionDistribution`, `noDistractionData`, `interruptionCount` strings (EN + JA) |
| `REQUIREMENTS.md` | Added RPT-17 and RPT-18 |

Closes #38