### PR TITLE
Enhance system version number display

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -342,3 +342,15 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | UX-4 | Tooltips must not be the sole affordance for any action.                                      |
 
 
+---
+
+## 13. Versioning
+
+
+| ID    | Requirement                                                                                                                                           |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| VER-1 | The app version is displayed in the top navigation bar as a semantic version string (e.g. `v1.0.1`), not a date string.                              |
+| VER-2 | The version is sourced from `package.json` and injected at build time, ensuring the displayed version always matches the deployed build.             |
+| VER-3 | Multiple releases on the same day are distinguished by incrementing the patch number (e.g. `v1.0.1` → `v1.0.2`).                                    |
+
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mytask",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -38,7 +38,7 @@ export function TopBar() {
         </nav>
       </div>
       <div className="flex items-center gap-3 text-sm">
-        <span className="text-gray-500 text-xs font-mono" title="Build date">{__BUILD_DATE__}</span>
+        <span className="text-gray-500 text-xs font-mono" title="Version">{__APP_VERSION__}</span>
         {syncing && <span className="text-gray-400 text-xs">{t.auth.syncing}</span>}
         <button
           onClick={signOut}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
 
-declare const __BUILD_DATE__: string;
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'node:fs'
+
+const { version } = JSON.parse(readFileSync('./package.json', 'utf-8')) as { version: string };
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: '/mytask/',
   define: {
-    __BUILD_DATE__: JSON.stringify(new Date().toISOString().slice(0, 10)),
+    __APP_VERSION__: JSON.stringify(`v${version}`),
   },
 })


### PR DESCRIPTION
## Summary

- Replaced the `__BUILD_DATE__` global (e.g. `2026-04-12`) with `__APP_VERSION__` (e.g. `v1.0.0`)
- The version is read from `package.json` at build time, so the displayed string always matches the deployed build
- Bumped `package.json` version from `0.0.0` → `1.0.0`
- Updated the TopBar `title` attribute from `"Build date"` to `"Version"`
- Multiple same-day releases are distinguished by incrementing the patch number (semver patch bump)

## Changes

| File | What changed |
|------|-------------|
| `package.json` | Version bumped from `0.0.0` to `1.0.0` |
| `vite.config.ts` | Reads `version` from `package.json` via `fs.readFileSync`; defines `__APP_VERSION__` as `v{version}` instead of `__BUILD_DATE__` |
| `src/vite-env.d.ts` | Type declaration changed from `__BUILD_DATE__` to `__APP_VERSION__` |
| `src/components/layout/TopBar.tsx` | Uses `__APP_VERSION__` with `title="Version"` |
| `REQUIREMENTS.md` | Added section 13 (Versioning) with VER-1, VER-2, VER-3 |

Closes #43