### PR TITLE
Enforce Release Tag Creation Rule for Every Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Create Release
+
+# Runs after every push to main. Creates a GitHub release + tag for the
+# current package.json version if one does not already exist.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # required to create tags and releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # fetch all tags so the existence check is accurate
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether this version tag already exists
+        id: check
+        run: |
+          if git tag --list | grep -qx "${{ steps.version.outputs.version }}"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "Release ${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project are documented here.
+A GitHub release tag is created for every entry (see [releases](https://github.com/acn-qiangchen/mytask/releases)).
+
+Format: `## [version] - YYYY-MM-DD` followed by categorised change bullets.
+
+---
+
+## [1.0.1] - 2026-04-12
+
+### Added
+- GitHub Actions release workflow (`.github/workflows/release.yml`) — automatically creates a GitHub release and tag on every `main` push when the `package.json` version is new (closes #47).
+- `CHANGELOG.md` — this file; required for every release going forward (closes #46).
+- Release process documented in `CLAUDE.md`.
+
+---
+
+## [1.0.0] - 2026-04-12
+
+### Added
+- Ticket management: register tickets (number + description), link tasks to tickets, view focus distribution grouped by ticket on the Reports page (closes #39).
+- Distraction distribution pie chart on the Reports page — groups interruptions by reason with count and percentage (closes #38).
+- Pause reason modal and interruption tracking (closes #25).
+- Task history date filter defaults to today (closes #30).
+- Report: merged weekly/monthly bar charts with toggle; date filter applied to focus distribution (closes #32).
+
+### Fixed
+- Report page filter now uses session dates instead of task planned dates, so a task worked on day Y appears in day Y's report (closes #37).
+- Date logic uses browser local timezone instead of UTC (closes #27).
+
+### Changed
+- Version display in the top bar changed from a build date string to a semver version string sourced from `package.json` (closes #43).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ npm run preview   # preview the production build locally
 
 Node version is pinned in `.nvmrc` (v20). The project uses `.claude/settings.local.json` (gitignored) to inject the correct `PATH` for the nvm-managed Node binary so Claude Code tools pick up the right version automatically.
 
-CI/CD: pushing to `main` triggers `.github/workflows/deploy.yml` → GitHub Pages at `https://acn-qiangchen.github.io/mytask/`.
+CI/CD: pushing to `main` triggers two workflows:
+- `.github/workflows/deploy.yml` → builds and deploys to GitHub Pages at `https://acn-qiangchen.github.io/mytask/`.
+- `.github/workflows/release.yml` → creates a GitHub release + tag for the current `package.json` version if one does not already exist.
 
 ## Architecture
 
@@ -77,6 +79,16 @@ Do not merge a feature PR without a corresponding `REQUIREMENTS.md` update.
 - Always work on a dedicated branch — never commit directly to `main` or `master`.
 - Branch names must include the GitHub issue number: `feature/issue-<N>-<short-description>` or `fix/issue-<N>-<short-description>`.
 - After pushing the branch, open a PR targeting `main`.
+
+## Release process
+
+A GitHub release tag is **required** for every release. The release workflow automates this:
+
+1. Bump `version` in `package.json` (e.g. `1.0.0` → `1.0.1`) as part of the feature/fix PR.
+2. Merge to `main` — `.github/workflows/release.yml` automatically creates the Git tag and GitHub release using the new version, with auto-generated release notes.
+3. A release is **not considered complete** until a GitHub release tag exists for that version.
+
+To distinguish multiple releases on the same day, increment the patch segment (`1.0.1`, `1.0.2`, …).
 
 ## UI / UX constraints
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -352,5 +352,7 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | VER-1 | The app version is displayed in the top navigation bar as a semantic version string (e.g. `v1.0.1`), not a date string.                              |
 | VER-2 | The version is sourced from `package.json` and injected at build time, ensuring the displayed version always matches the deployed build.             |
 | VER-3 | Multiple releases on the same day are distinguished by incrementing the patch number (e.g. `v1.0.1` → `v1.0.2`).                                    |
+| VER-4 | Every release must have a corresponding GitHub release tag. The release workflow (`.github/workflows/release.yml`) creates this automatically on each `main` push when the version is new. |
+| VER-5 | A `CHANGELOG.md` entry must be added for every release, documenting new features, bug fixes, and breaking changes.                                   |
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mytask",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Added `.github/workflows/release.yml` — automatically creates a GitHub release + tag on every `main` push when the `package.json` version has no existing tag
- Added `CHANGELOG.md` with entries for v1.0.0 and v1.0.1
- Documented the release process in `CLAUDE.md` (bump version → merge to main → tag created automatically)
- Bumped version to `1.0.1` for this release
- Added VER-4 and VER-5 to `REQUIREMENTS.md`

## How the release workflow works

1. Triggers on every push to `main`
2. Reads the version from `package.json` (e.g. `1.0.1`)
3. Checks whether a tag `v1.0.1` already exists (via `git tag --list`)
4. If it does **not** exist: creates a GitHub release with `--generate-notes` (auto-generates release notes from merged PRs since the last tag)
5. If it already exists: no-op — safe to re-run

## Rule going forward

A release is not complete until a GitHub release tag exists. To publish a release:
1. Bump `version` in `package.json` in the feature PR
2. Merge to `main` — the workflow does the rest
3. Add a `CHANGELOG.md` entry

Closes #47