### PR TITLE
Require Release Notes/Changelog for Each Release

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,48 @@
+name: Changelog Check
+
+# Enforces that CHANGELOG.md is updated whenever package.json version is bumped.
+# Runs on every pull request targeting main.
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  changelog:
+    name: Require CHANGELOG.md update on version bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # needed to read the base branch file
+
+      - name: Compare versions and check changelog
+        run: |
+          BASE_VERSION=$(git show "origin/${{ github.base_ref }}":package.json | jq -r '.version')
+          CURRENT_VERSION=$(jq -r '.version' package.json)
+
+          echo "Base version  : $BASE_VERSION"
+          echo "Branch version: $CURRENT_VERSION"
+
+          if [ "$BASE_VERSION" = "$CURRENT_VERSION" ]; then
+            echo "✅ Version unchanged ($CURRENT_VERSION) — no changelog entry required."
+            exit 0
+          fi
+
+          echo "Version bumped: $BASE_VERSION → $CURRENT_VERSION"
+
+          CHANGELOG_CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -c "^CHANGELOG\.md$" || true)
+
+          if [ "$CHANGELOG_CHANGED" -eq 0 ]; then
+            echo ""
+            echo "❌ CHANGELOG.md was not updated."
+            echo ""
+            echo "The version was bumped from $BASE_VERSION to $CURRENT_VERSION, so a"
+            echo "CHANGELOG.md entry is required. Add a section like:"
+            echo ""
+            echo "  ## [$CURRENT_VERSION] - $(date -u +%Y-%m-%d)"
+            echo "  ### Added / Fixed / Changed"
+            echo "  - Describe what changed in this release."
+            exit 1
+          fi
+
+          echo "✅ CHANGELOG.md was updated for v$CURRENT_VERSION."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format: `## [version] - YYYY-MM-DD` followed by categorised change bullets.
 
 ---
 
+## [1.0.2] - 2026-04-12
+
+### Added
+- CI check workflow (`.github/workflows/changelog-check.yml`) — blocks PR merges when the version is bumped but `CHANGELOG.md` is not updated (closes #46).
+- Updated `CLAUDE.md` release process to document the changelog requirement.
+
+---
+
 ## [1.0.1] - 2026-04-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,9 @@ Do not merge a feature PR without a corresponding `REQUIREMENTS.md` update.
 A GitHub release tag is **required** for every release. The release workflow automates this:
 
 1. Bump `version` in `package.json` (e.g. `1.0.0` → `1.0.1`) as part of the feature/fix PR.
-2. Merge to `main` — `.github/workflows/release.yml` automatically creates the Git tag and GitHub release using the new version, with auto-generated release notes.
-3. A release is **not considered complete** until a GitHub release tag exists for that version.
+2. Add a `CHANGELOG.md` entry for the new version — the PR check (`.github/workflows/changelog-check.yml`) **blocks merge** if the version was bumped but `CHANGELOG.md` was not updated.
+3. Merge to `main` — `.github/workflows/release.yml` automatically creates the Git tag and GitHub release using the new version, with auto-generated release notes.
+4. A release is **not considered complete** until a GitHub release tag exists for that version.
 
 To distinguish multiple releases on the same day, increment the patch segment (`1.0.1`, `1.0.2`, …).
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -354,5 +354,6 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | VER-3 | Multiple releases on the same day are distinguished by incrementing the patch number (e.g. `v1.0.1` → `v1.0.2`).                                    |
 | VER-4 | Every release must have a corresponding GitHub release tag. The release workflow (`.github/workflows/release.yml`) creates this automatically on each `main` push when the version is new. |
 | VER-5 | A `CHANGELOG.md` entry must be added for every release, documenting new features, bug fixes, and breaking changes.                                   |
+| VER-6 | The changelog CI check (`.github/workflows/changelog-check.yml`) enforces VER-5: a PR that bumps the version in `package.json` will fail the check if `CHANGELOG.md` is not also updated. |
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mytask",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

Adds a CI check that enforces `CHANGELOG.md` is updated whenever `package.json` version is bumped in a PR.

## How the check works

`.github/workflows/changelog-check.yml` runs on every PR targeting `main`:

1. Reads the version from `package.json` in the PR branch
2. Reads the version from `package.json` on the base branch (`main`)
3. If versions are **the same** → passes (no release = no changelog needed)
4. If version was **bumped** → checks whether `CHANGELOG.md` was also modified in the PR
5. If `CHANGELOG.md` was not updated → **fails** with a clear error message and example of what to add

## Changes

| File | What changed |
|------|-------------|
| `.github/workflows/changelog-check.yml` | New PR check workflow |
| `CHANGELOG.md` | Added v1.0.2 entry |
| `CLAUDE.md` | Step 2 of release process now explicitly mentions the changelog requirement and CI check |
| `REQUIREMENTS.md` | Added VER-6 |
| `package.json` | Bumped to `1.0.2` |

## Example failure message

```
❌ CHANGELOG.md was not updated.

The version was bumped from 1.0.1 to 1.0.2, so a
CHANGELOG.md entry is required. Add a section like:

  ## [1.0.2] - 2026-04-12
  ### Added / Fixed / Changed
  - Describe what changed in this release.
```

Closes #46