### PR TITLE
[bug] Show completed tasks of the same day based on the completed date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Format: `## [version] - YYYY-MM-DD` followed by categorised change bullets.
 
 ---
 
+## [1.0.5] - 2026-05-10
+
+### Fixed
+- Completed tasks created on a previous day now remain visible on the timer page when completed today (closes #53).
+  - Previously, marking an older task complete caused it to immediately disappear because the filter compared the task's creation date instead of its completion date.
+  - The completed-tasks filter and "Clear completed" action now use `completedAt` date rather than the task's `date` field.
+
+---
+
 ## [1.0.4] - 2026-05-04
 
 ### Fixed

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -95,7 +95,7 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 
 | ID     | Requirement                                                                                                                                                                  |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| TSK-1  | The timer page shows all **pending (not completed, not archived)** tasks regardless of their date, plus today's completed tasks.                                             |
+| TSK-1  | The timer page shows all **pending (not completed, not archived)** tasks regardless of their date, plus tasks completed today (determined by `completedAt` date, not the task's creation date). |
 | TSK-2  | Pending tasks are shown above completed tasks.                                                                                                                               |
 | TSK-3  | Pending tasks are sorted by their `order` value (drag-and-drop order), then by `createdAt` for tasks without an order. Delayed tasks share the same ordering as today's tasks. |
 | TSK-4  | Completed tasks are sorted by `completedAt` descending (most recently completed first).                                                                                      |
@@ -134,7 +134,7 @@ All date values (task date, session date, "today" comparisons, weekly/monthly ch
 | TSK-14 | Marking a completed task as incomplete sets `completed=false` and clears `completedAt`.                                                                                   |
 | TSK-15 | The user can delete a task via a delete icon. A confirmation dialog is shown before deletion.                                                                             |
 | TSK-16 | A "Clear completed" button appears when at least one task for today is complete.                                                                                          |
-| TSK-17 | "Clear completed" sets `archivedAt` on all completed tasks for today, hiding them from the timer page. Archived tasks remain visible in task history on the Reports page. |
+| TSK-17 | "Clear completed" sets `archivedAt` on all completed tasks whose `completedAt` date is today (regardless of creation date), hiding them from the timer page. Archived tasks remain visible in task history on the Reports page. |
 
 
 ### 4.5 Reordering Tasks

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mytask",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/context/reducer.test.ts
+++ b/src/context/reducer.test.ts
@@ -112,6 +112,63 @@ describe('REORDER_TASKS', () => {
   });
 });
 
+describe('CLEAR_COMPLETED_TASKS', () => {
+  it('archives a task completed on the given date', () => {
+    const task = makeTask({ id: 'a', completed: true, completedAt: '2026-05-10T10:00:00.000Z' });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBeDefined();
+  });
+
+  it('archives a task created on a past day but completed today (regression for #53)', () => {
+    const task = makeTask({
+      id: 'a',
+      date: '2026-05-08',
+      completed: true,
+      completedAt: '2026-05-10T10:00:00.000Z',
+    });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBeDefined();
+  });
+
+  it('does not archive a task completed on a different day', () => {
+    const task = makeTask({ id: 'a', completed: true, completedAt: '2026-05-09T10:00:00.000Z' });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBeUndefined();
+  });
+
+  it('does not archive incomplete tasks', () => {
+    const task = makeTask({ id: 'a', date: '2026-05-10', completed: false });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBeUndefined();
+  });
+
+  it('does not re-archive an already archived task', () => {
+    const archivedAt = '2026-05-10T08:00:00.000Z';
+    const task = makeTask({ id: 'a', completed: true, completedAt: '2026-05-10T09:00:00.000Z', archivedAt });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBe(archivedAt);
+  });
+
+  it('falls back to task date when completedAt is missing', () => {
+    const task = makeTask({ id: 'a', date: '2026-05-10', completed: true });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.tasks.find(t => t.id === 'a')?.archivedAt).toBeDefined();
+  });
+
+  it('sets updatedAt', () => {
+    const task = makeTask({ id: 'a', completed: true, completedAt: '2026-05-10T10:00:00.000Z' });
+    const state = makeState([task]);
+    const next = appReducer(state, { type: 'CLEAR_COMPLETED_TASKS', payload: '2026-05-10' });
+    expect(next.updatedAt).toBeDefined();
+  });
+});
+
 describe('ADD_INTERRUPTION', () => {
   function makeInterruption(overrides: Partial<Interruption> = {}): Interruption {
     return {

--- a/src/context/reducer.ts
+++ b/src/context/reducer.ts
@@ -42,11 +42,11 @@ export function appReducer(state: AppState, action: Action): AppState {
     case 'CLEAR_COMPLETED_TASKS':
       return {
         ...state,
-        tasks: state.tasks.map(t =>
-          t.date === action.payload && t.completed && !t.archivedAt
-            ? { ...t, archivedAt: new Date().toISOString() }
-            : t
-        ),
+        tasks: state.tasks.map(t => {
+          if (!t.completed || t.archivedAt) return t;
+          const completionDate = t.completedAt ? t.completedAt.slice(0, 10) : t.date;
+          return completionDate === action.payload ? { ...t, archivedAt: new Date().toISOString() } : t;
+        }),
         updatedAt: new Date().toISOString(),
       };
 

--- a/src/pages/TimerPage.tsx
+++ b/src/pages/TimerPage.tsx
@@ -79,7 +79,11 @@ export function TimerPage() {
       return ao !== bo ? ao - bo : a.createdAt.localeCompare(b.createdAt);
     });
   const completedTasks = state.tasks
-    .filter(t => t.completed && t.date === today && !t.archivedAt)
+    .filter(t => {
+      if (!t.completed || t.archivedAt) return false;
+      const completionDate = t.completedAt ? t.completedAt.slice(0, 10) : t.date;
+      return completionDate === today;
+    })
     .sort((a, b) => (a.completedAt ?? '').localeCompare(b.completedAt ?? ''));
   const todayTasks = [...pendingTasks, ...completedTasks];
   const hasCompleted = completedTasks.length > 0;


### PR DESCRIPTION
## Summary

- Tasks created on a previous day that are marked complete today were immediately disappearing from the timer page — they were filtered using the task's `date` (creation date) instead of `completedAt` date.
- Fixed the `completedTasks` filter in `TimerPage.tsx` to use `completedAt.slice(0, 10)` for the date comparison.
- Fixed the `CLEAR_COMPLETED_TASKS` reducer action to archive tasks based on `completedAt` date, not creation date.
- Added 7 unit tests in `reducer.test.ts` covering the happy path, the regression case, and edge cases (no `completedAt`, already archived, wrong day).
- Updated `REQUIREMENTS.md` (TSK-1, TSK-17) to reflect the correct behaviour.

Closes #53

## Test plan

- [ ] Mark a task created on a past day as complete — it should remain visible on the timer page until "Clear completed" is clicked.
- [ ] "Clear completed" correctly archives tasks completed today regardless of their creation date.
- [ ] Tasks completed on a different day are not affected.
- [ ] All unit tests pass (`npm test -- --run`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)